### PR TITLE
feat: add variant support

### DIFF
--- a/pxr/usd/sdf/wrapLayerJs.cpp
+++ b/pxr/usd/sdf/wrapLayerJs.cpp
@@ -168,6 +168,7 @@ EMSCRIPTEN_BINDINGS(SdfLayer) {
     .function("ExportToString", &ExportToString)
     .function("GetDisplayName", &pxr::SdfLayer::GetDisplayName)
     .function("GetPrimAtPath", &pxr::SdfLayer::GetPrimAtPath)
+    .function("GetDefaultPrim", &pxr::SdfLayer::GetDefaultPrim)
     .function("GetPropertyAtPath", /*&pxr::SdfLayer::GetPropertyAtPath*/ &_GetPropertyAtPath, allow_raw_pointer<ret_val>())
     .function("SetTimeSample", &_SetTimeSample)
     .function("Traverse", &traverse)

--- a/pxr/usd/usd/wrapPrimJs.cpp
+++ b/pxr/usd/usd/wrapPrimJs.cpp
@@ -26,6 +26,7 @@
 #include "pxr/usd/usd/attribute.h"
 #include "pxr/usd/usd/prim.h"
 #include "pxr/usd/usd/references.h"
+#include "pxr/usd/usd/variantSets.h"
 
 #include <emscripten/bind.h>
 using namespace emscripten;
@@ -36,12 +37,45 @@ GetPropertyNames(pxr::UsdPrim& self)
     return self.GetPropertyNames();
 };
 
+
+std::vector<std::string>
+GetVariantSets(pxr::UsdPrim& self)
+{
+    pxr::UsdVariantSets variantSets = self.GetVariantSets();
+    return variantSets.GetNames();
+};
+
+bool
+SetVariant(pxr::UsdPrim& self, const std::string& variantSetName, const std::string& variantName){
+    pxr::UsdVariantSets variantSets = self.GetVariantSets();
+    return variantSets.SetSelection(variantSetName, variantName);
+}
+
+std::vector<std::string>
+GetVariantSetOptions(pxr::UsdPrim& self, const std::string& variantSetName){
+    pxr::UsdVariantSets variantSets = self.GetVariantSets();
+    pxr::UsdVariantSet variantSet = variantSets.GetVariantSet(variantSetName);
+    return variantSet.GetVariantNames();
+}
+
+std::string
+GetVariantSelection(pxr::UsdPrim& self, const std::string& variantSetName){
+    pxr::UsdVariantSets variantSets = self.GetVariantSets();
+    pxr::UsdVariantSet variantSet = variantSets.GetVariantSet(variantSetName);
+    return variantSet.GetVariantSelection();
+}
+
 EMSCRIPTEN_BINDINGS(UsdPrim) {
+  emscripten::register_vector<std::string>("VectorString");
   class_<pxr::UsdPrim>("UsdPrim")
     .function("GetAttribute", &pxr::UsdPrim::GetAttribute)
     .function("GetTypeName", &pxr::UsdPrim::GetTypeName)
     .function("GetAttributes", &pxr::UsdPrim::GetAttributes)
     .function("GetPropertyNames", &GetPropertyNames)
     .function("GetReferences", &pxr::UsdPrim::GetReferences)
+    .function("GetVariantSets", &GetVariantSets)
+    .function("SetVariant", &SetVariant)
+    .function("GetVariantSetOptions", &GetVariantSetOptions)
+    .function("GetVariantSelection", &GetVariantSelection)
     ;
 }

--- a/pxr/usd/usd/wrapStageJs.cpp
+++ b/pxr/usd/usd/wrapStageJs.cpp
@@ -97,7 +97,8 @@ char GetUpAxis(pxr::UsdStage& self)
     pxr::UsdStageWeakPtr stageWeakPtr(stageRefPtr);
 
     // Use the weak pointer to get the stage up axis
-    return pxr::UsdGeomGetStageUpAxis(stageWeakPtr) == pxr::UsdGeomTokens->z ? 'z' : 'y';
+    auto upAxisToken = pxr::UsdGeomGetStageUpAxis(stageWeakPtr);
+    return upAxisToken == pxr::UsdGeomTokens->y ? 'y' : upAxisToken == pxr::UsdGeomTokens->z ? 'z' : 'x';
 }
 
 void MyExit()

--- a/pxr/usd/usd/wrapStageJs.cpp
+++ b/pxr/usd/usd/wrapStageJs.cpp
@@ -26,6 +26,8 @@
 #include "pxr/usd/sdf/wrapPathJs.h"
 #include "pxr/base/tf/wrapTokenJs.h"
 #include "pxr/usd/usd/emscriptenPtrRegistrationHelper.h"
+#include "pxr/usd/usdGeom/metrics.h"
+#include "pxr/usd/usdGeom/tokens.h"
 #include <functional>
 
 #include <iostream>
@@ -86,6 +88,18 @@ void Export(pxr::UsdStage& self, const std::string &fileName, bool addFileFormat
     self.Export(fileName, addFileFormatComments, arguments);
 }
 
+char GetUpAxis(pxr::UsdStage& self)
+{
+    // Convert the UsdStage& to a UsdStageRefPtr
+    pxr::UsdStageRefPtr stageRefPtr(&self);
+
+    // Convert the UsdStageRefPtr to a UsdStageWeakPtr
+    pxr::UsdStageWeakPtr stageWeakPtr(stageRefPtr);
+
+    // Use the weak pointer to get the stage up axis
+    return pxr::UsdGeomGetStageUpAxis(stageWeakPtr) == pxr::UsdGeomTokens->z ? 'z' : 'y';
+}
+
 void MyExit()
 {
     emscripten_force_exit(0);
@@ -109,12 +123,12 @@ EMSCRIPTEN_BINDINGS(UsdStage) {
 
     .class_function("Open", &Open)
     .class_function("Open", select_overload<pxr::UsdStageRefPtr(const pxr::SdfLayerHandle &layer, pxr::UsdStage::InitialLoadSet)>(&pxr::UsdStage::Open))
-
     .class_function("Exit", &MyExit)
     .function("ExportToString", &exportToString<pxr::UsdStage>)
     .function("DefinePrim", &pxr::UsdStage::DefinePrim)
     .function("Download", &download)
     .function("Export", &Export)
+    .function("GetUpAxis", &GetUpAxis)
     .function("GetPrimAtPath", &pxr::UsdStage::GetPrimAtPath)
     .function("SetDefaultPrim", &pxr::UsdStage::SetDefaultPrim)
     .function("OverridePrim", &pxr::UsdStage::OverridePrim)

--- a/pxr/usdImaging/hdEmscripten/CMakeLists.txt
+++ b/pxr/usdImaging/hdEmscripten/CMakeLists.txt
@@ -89,7 +89,7 @@ set_target_properties(${BINDINGS_NAME}
 target_link_options(${BINDINGS_NAME} PRIVATE "SHELL: -Oz -s EXPORT_NAME='getUsdModule' \
     -s MODULARIZE=1 -lembind -s PTHREAD_POOL_SIZE=10 -s ASYNCIFY -s ASYNCIFY_ADVISE \
     -sIMPORTED_MEMORY=1 --pre-js ${CMAKE_CURRENT_SOURCE_DIR}/js/MemoryConfiguration.js  \
-    -s ASYNCIFY_REMOVE=['__vfprintf_internal','__fseeko_unlocked','*::itanium_demangle::*','*VtArray*','*_Clear*','*dlfree*','*TfType*','*Tf_Registry*','*Tf_Post*','*tao::PXR_INTERNAL_NS_pegtl*','*UsdObject*','*TfSmallVector*','*TfMallocTag*','*__cxa_guard_acquire*,'*UsdSchema*','*Usd_CrateFile*','*TfEnum*','*TfErrorMark*','*VtStreamOutArray*','*SdfSpec*']")
+    ")
 
 install(
     FILES


### PR DESCRIPTION
- added support to get all variant sets on a prim, set the current active variant, get all the variant options, and get the current variant selection
- added support to get the default prim on a layer
- removing asyncify_remove as it's too tedious to maintain